### PR TITLE
Detect clang version at end of line

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -130,7 +130,7 @@ async function getClangVersion(binPath: string): Promise<ClangVersion|null> {
     return null;
   }
   const lines = exec.stderr.split('\n');
-  const version_re = /^(?:Apple LLVM|.*clang) version ([^\s-]+)[\s-]/;
+  const version_re = /^(?:Apple LLVM|.*clang) version ([^\s-]+)(?:[\s-]|$)/;
   let version: string = "";
   let fullVersion: string = "";
   for (const line of lines) {


### PR DESCRIPTION
The clang version regex expects the version number to be followed by white space or a dash. This is not the case for Gentoo builds.
Example output:
```
$ clang -v
clang version 12.0.0
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/lib/llvm/12/bin
(snip)
```

This patch modifies the regex to detect version numbers ending at end-of-line.